### PR TITLE
supervisorphp/configuration - renderKeyValuePair() problem when creating 'Group' section - SOLVED

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -102,10 +102,8 @@ class Renderer
         $value = $this->normalizeValue($value);
 
         if (is_array($value)) {
-            foreach ($value as $v) {
-                $output[] = sprintf('%s[] = %s', $key, $v);
-            }
-        } else {
+	   $output[] = sprintf('%s = %s', $key, join($value, ','));
+	} else {
             $output[] = sprintf('%s = %s', $key, $value);
         }
 

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -102,7 +102,7 @@ class Renderer
         $value = $this->normalizeValue($value);
 
         if (is_array($value)) {
-	   $output[] = sprintf('%s = %s', $key, join($value, ','));
+	    $output[] = sprintf('%s = %s', $key, join($value, ','));
 	} else {
             $output[] = sprintf('%s = %s', $key, $value);
         }


### PR DESCRIPTION
I came across the use of this library as a dependency of [supervisorphp/configuration](https://github.com/supervisorphp/configuration). I was facing an issue when it generated the `Group` sections for a supervisor configuration. 

With the code:
```
use Indigo\Ini\Renderer;
use Supervisor\Configuration\Configuration;
use Supervisor\Configuration\Section\Group;
$config   = new Configuration;
$renderer = new Renderer;
$section = new Group('test', ['programs' => ['test0', 'test1']]);
$config->addSection($section);
$renderer->render($config->toArray());
```

I was getting the following output:
```
[group:test]
programs[] = test0
programs[] = test1
```

According to the [Supervisor Group section documentation](http://supervisord.org/configuration.html#group-x-section-settings), the above was not valid. After fixing the `renderKeyValuePair() ` to concatenate the program values into comma separated list, it gave the correct result and removed the unnecessary brackets `[]`:

```
[group:test]
programs = test0,test1
```